### PR TITLE
fix: don't query ERC-20's symbol, name, and decimals on-chain

### DIFF
--- a/src/constants/index.ts.template
+++ b/src/constants/index.ts.template
@@ -11,3 +11,15 @@ export const baseTokenSymbolMap = new TypedMap<Address, string>()
 {{ #pools }}
 baseTokenSymbolMap.set(Address.fromString("{{ baseAddress }}"), "{{ baseSymbol }}")
 {{ /pools }}
+
+export const collateralMap = new Map<string, Map<string, string>>()
+
+{{ #collaterals }}
+export const {{ symbol }} = new Map<string, string>()
+{{ symbol }}.set("id", "{{ address }}")
+{{ symbol }}.set("name", "{{ name }}")
+{{ symbol }}.set("symbol", "{{ symbol }}")
+{{ symbol }}.set("decimals", "{{ decimals }}")
+collateralMap.set("{{ address }}", {{ symbol }})
+
+{{ /collaterals }}

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,74 +1,60 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts"
-import { ERC20 } from "../../generated/CollateralManager/ERC20"
-import { ERC20NameBytes } from "../../generated/CollateralManager/ERC20NameBytes"
-import { ERC20SymbolBytes } from "../../generated/CollateralManager/ERC20SymbolBytes"
+
+interface Erc20 {
+    id: string
+    name: string
+    symbol: string
+    decimals: string
+}
+
+const collateralMap: { [id: string]: Erc20 } = {
+    "0x4200000000000000000000000000000000000006":
+        {
+            "id": "0x4200000000000000000000000000000000000006",
+            "name": "Wrapped Ether",
+            "symbol": "WETH",
+            "decimals": "18",
+        },
+    "0x7f5c764cbc14f9669b88837ca1490cca17c31607":
+        {
+            "id": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
+            "name": "USD Coin",
+            "symbol": "USDC",
+            "decimals": "6",
+        },
+    "0x2e3d870790dc77a83dd1d18184acc7439a53f475":
+        {
+            "id": "0x2e3d870790dc77a83dd1d18184acc7439a53f475",
+            "name": "Frax",
+            "symbol": "FRAX",
+            "decimals": "18",
+        },
+}
 
 function isNullEthValue(value: string): boolean {
     return value == "0x0000000000000000000000000000000000000000000000000000000000000001"
 }
 
 export function fetchTokenSymbol(tokenAddress: Address): string {
-    let contract = ERC20.bind(tokenAddress)
-    let contractSymbolBytes = ERC20SymbolBytes.bind(tokenAddress)
-
-    // try types string and bytes32 for symbol
-    let symbolValue = "unknown"
-    let symbolResult = contract.try_symbol()
-    if (symbolResult.reverted) {
-        let symbolResultBytes = contractSymbolBytes.try_symbol()
-        if (!symbolResultBytes.reverted) {
-            // for broken tokens that have no symbol function exposed
-            if (!isNullEthValue(symbolResultBytes.value.toHexString())) {
-                symbolValue = symbolResultBytes.value.toString()
-            }
-        }
-    } else {
-        symbolValue = symbolResult.value
+    const erc20 = collateralMap[tokenAddress.toHexString()]
+    if (!erc20) {
+        return "unknown"
     }
-
-    return symbolValue
+    return erc20.symbol
 }
 
 export function fetchTokenName(tokenAddress: Address): string {
-    let contract = ERC20.bind(tokenAddress)
-    let contractNameBytes = ERC20NameBytes.bind(tokenAddress)
-
-    // try types string and bytes32 for name
-    let nameValue = "unknown"
-    let nameResult = contract.try_name()
-    if (nameResult.reverted) {
-        let nameResultBytes = contractNameBytes.try_name()
-        if (!nameResultBytes.reverted) {
-            // for broken tokens that have no name function exposed
-            if (!isNullEthValue(nameResultBytes.value.toHexString())) {
-                nameValue = nameResultBytes.value.toString()
-            }
-        }
-    } else {
-        nameValue = nameResult.value
+    const erc20 = collateralMap[tokenAddress.toHexString()]
+    if (!erc20) {
+        return "unknown"
     }
-
-    return nameValue
-}
-
-export function fetchTokenTotalSupply(tokenAddress: Address): BigInt {
-    let contract = ERC20.bind(tokenAddress)
-    let totalSupplyValue = null
-    let totalSupplyResult = contract.try_totalSupply()
-    if (!totalSupplyResult.reverted) {
-        totalSupplyValue = totalSupplyResult as i32
-    }
-    return BigInt.fromI32(totalSupplyValue as i32)
+    return erc20.name
 }
 
 export function fetchTokenDecimals(tokenAddress: Address): BigInt {
-    let contract = ERC20.bind(tokenAddress)
-    // try types uint8 for decimals
-    let decimalValue = null
-    let decimalResult = contract.try_decimals()
-    if (!decimalResult.reverted) {
-        decimalValue = decimalResult.value
+    const erc20 = collateralMap[tokenAddress.toHexString()]
+    if (!erc20) {
+        return BigInt.fromString("18")
     }
-
-    return BigInt.fromI32(decimalValue as i32)
+    return BigInt.fromString(erc20.decimals)
 }

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,60 +1,55 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts"
 
-interface Erc20 {
-    id: string
-    name: string
-    symbol: string
-    decimals: string
-}
+// TODO: will it be easier if we create a GraphQL table to store these data?
+type StrStrMap = Map<string, string>
 
-const collateralMap: { [id: string]: Erc20 } = {
-    "0x4200000000000000000000000000000000000006":
-        {
-            "id": "0x4200000000000000000000000000000000000006",
-            "name": "Wrapped Ether",
-            "symbol": "WETH",
-            "decimals": "18",
-        },
-    "0x7f5c764cbc14f9669b88837ca1490cca17c31607":
-        {
-            "id": "0x7f5c764cbc14f9669b88837ca1490cca17c31607",
-            "name": "USD Coin",
-            "symbol": "USDC",
-            "decimals": "6",
-        },
-    "0x2e3d870790dc77a83dd1d18184acc7439a53f475":
-        {
-            "id": "0x2e3d870790dc77a83dd1d18184acc7439a53f475",
-            "name": "Frax",
-            "symbol": "FRAX",
-            "decimals": "18",
-        },
-}
+const wethMap = new Map<string, string>()
+wethMap.set("id", "0x4200000000000000000000000000000000000006")
+wethMap.set("name", "Wrapped Ether")
+wethMap.set("symbol", "WETH")
+wethMap.set("decimals", "18")
+
+const usdcMap = new Map<string, string>()
+usdcMap.set("id", "0x7f5c764cbc14f9669b88837ca1490cca17c31607")
+usdcMap.set("name", "USD Coin")
+usdcMap.set("symbol", "USDC")
+usdcMap.set("decimals", "6")
+
+const fraxMap = new Map<string, string>()
+fraxMap.set("id", "0x2e3d870790dc77a83dd1d18184acc7439a53f475")
+fraxMap.set("name", "Frax")
+fraxMap.set("symbol", "FRAX")
+fraxMap.set("decimals", "18")
+
+const collateralMap = new Map<string, StrStrMap>()
+collateralMap.set("0x4200000000000000000000000000000000000006", wethMap)
+collateralMap.set("0x7f5c764cbc14f9669b88837ca1490cca17c31607", usdcMap)
+collateralMap.set("0x2e3d870790dc77a83dd1d18184acc7439a53f475", fraxMap)
 
 function isNullEthValue(value: string): boolean {
     return value == "0x0000000000000000000000000000000000000000000000000000000000000001"
 }
 
 export function fetchTokenSymbol(tokenAddress: Address): string {
-    const erc20 = collateralMap[tokenAddress.toHexString()]
+    const erc20 = collateralMap.get(tokenAddress.toHexString())
     if (!erc20) {
         return "unknown"
     }
-    return erc20.symbol
+    return erc20.get("symbol")
 }
 
 export function fetchTokenName(tokenAddress: Address): string {
-    const erc20 = collateralMap[tokenAddress.toHexString()]
+    const erc20 = collateralMap.get(tokenAddress.toHexString())
     if (!erc20) {
         return "unknown"
     }
-    return erc20.name
+    return erc20.get("name")
 }
 
 export function fetchTokenDecimals(tokenAddress: Address): BigInt {
-    const erc20 = collateralMap[tokenAddress.toHexString()]
+    const erc20 = collateralMap.get(tokenAddress.toHexString())
     if (!erc20) {
         return BigInt.fromString("18")
     }
-    return BigInt.fromString(erc20.decimals)
+    return BigInt.fromString(erc20.get("decimals"))
 }

--- a/src/utils/token.ts
+++ b/src/utils/token.ts
@@ -1,34 +1,5 @@
 import { Address, BigInt } from "@graphprotocol/graph-ts"
-
-// TODO: will it be easier if we create a GraphQL table to store these data?
-type StrStrMap = Map<string, string>
-
-const wethMap = new Map<string, string>()
-wethMap.set("id", "0x4200000000000000000000000000000000000006")
-wethMap.set("name", "Wrapped Ether")
-wethMap.set("symbol", "WETH")
-wethMap.set("decimals", "18")
-
-const usdcMap = new Map<string, string>()
-usdcMap.set("id", "0x7f5c764cbc14f9669b88837ca1490cca17c31607")
-usdcMap.set("name", "USD Coin")
-usdcMap.set("symbol", "USDC")
-usdcMap.set("decimals", "6")
-
-const fraxMap = new Map<string, string>()
-fraxMap.set("id", "0x2e3d870790dc77a83dd1d18184acc7439a53f475")
-fraxMap.set("name", "Frax")
-fraxMap.set("symbol", "FRAX")
-fraxMap.set("decimals", "18")
-
-const collateralMap = new Map<string, StrStrMap>()
-collateralMap.set("0x4200000000000000000000000000000000000006", wethMap)
-collateralMap.set("0x7f5c764cbc14f9669b88837ca1490cca17c31607", usdcMap)
-collateralMap.set("0x2e3d870790dc77a83dd1d18184acc7439a53f475", fraxMap)
-
-function isNullEthValue(value: string): boolean {
-    return value == "0x0000000000000000000000000000000000000000000000000000000000000001"
-}
+import { collateralMap } from "../constants"
 
 export function fetchTokenSymbol(tokenAddress: Address): string {
     const erc20 = collateralMap.get(tokenAddress.toHexString())

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -169,12 +169,6 @@ dataSources:
       abis:
         - name: CollateralManager
           file: ./abis/CollateralManager.json
-        - name: ERC20
-          file: ./external-abis/ERC20.json
-        - name: ERC20SymbolBytes
-          file: ./external-abis/ERC20SymbolBytes.json
-        - name: ERC20NameBytes
-          file: ./external-abis/ERC20NameBytes.json
       eventHandlers:
         - event: CollateralAdded(indexed address,address,uint24,uint24,uint256)
           handler: handleCollateralAdded


### PR DESCRIPTION
Don't query ERC-20's symbol, name and decimals on-chain because it might slow down the graph processing.