### PR TITLE
switch to Satsuma IPFS gateway as they suggested

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "deploy-self-hosted:optimism-kovan-dev2": "npm run codegen:optimism-kovan-dev2 && graph deploy --version-label $(git rev-parse --short HEAD) --node http://127.0.0.1:8020 --ipfs https://api.thegraph.com/ipfs/ perpetual-protocol/perpetual-v2-optimism-kovan-dev2",
         "deploy-self-hosted:optimism-goerli": "npm run codegen:optimism-goerli && graph deploy --version-label $(git rev-parse --short HEAD) --node http://127.0.0.1:8020 --ipfs https://api.thegraph.com/ipfs/ perpetual-protocol/perpetual-v2-optimism-goerli",
         "deploy-self-hosted:optimism": "npm run codegen:optimism && graph deploy --version-label $(git rev-parse --short HEAD) --node http://127.0.0.1:8020 --ipfs https://api.thegraph.com/ipfs/ perpetual-protocol/perpetual-v2-optimism",
-        "deploy-satsuma:optimism": "npm run codegen-satsuma:optimism && graph deploy --version-label $(git rev-parse --short HEAD) --node https://app.satsuma.xyz/api/subgraphs/deploy --ipfs https://api.thegraph.com/ipfs/ --deploy-key $SATSUMA_DEPLOY_KEY perpetual-v2-optimism",
+        "deploy-satsuma:optimism": "npm run codegen-satsuma:optimism && graph deploy --version-label $(git rev-parse --short HEAD) --node https://app.satsuma.xyz/api/subgraphs/deploy --ipfs https://ipfs.satsuma.xyz --deploy-key $SATSUMA_DEPLOY_KEY perpetual-v2-optimism",
         "health-check": "ts-node ./scripts/healthCheck.ts",
         "list-subgraph-ids": "ts-node ./scripts/listSubgraphIds.ts"
     },


### PR DESCRIPTION
Got an email from Satsuma:

> In light of the recent [instabilities](https://discord.com/channels/438038660412342282/791444347823980604/1111648520655601734) with The Graph's IPFS gateway causing deployments and data fetching from IPFS to fail, we've decided to switch to our own gateway. We're constantly striving to improve the reliability of our service, and removing this dependency is a step in this direction.<br>
To deploy to Satsuma's IPFS gateway, please add the `--ipfs https://ipfs.satsuma.xyz/` flag to the [deploy command](https://docs.satsuma.xyz/hosted-subgraphs/subgraph-deploys). We will continue to support deploying to The Graph's gateway until 6/23, after which, deployments to their gateway may be slow or unreliable.<br>
Additionally, if your subgraph reads data from IPFS using the IPFS AssemblyScript API (`ipfs.map`, `[ipfs.cat](http://ipfs.cat/)`, etc), we highly recommend switching to [file data sources](https://thegraph.com/docs/en/developing/creating-a-subgraph/#file-data-sources), which can more reliably fetch files and is more performant.

So switch to `--ipfs https://ipfs.satsuma.xyz/` for Satsuma deployment. We can also change other deployments to Satsuma IPFS gateway if encountering some errors.